### PR TITLE
Add support for months in parse function

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var h = m * 60;
 var d = h * 24;
 var w = d * 7;
 var y = d * 365.25;
+var M = y / 12;
 
 /**
  * Parse or format the given `val`.
@@ -48,7 +49,7 @@ module.exports = function (val, options) {
 function parse(str) {
   str = String(str);
 
-  const l_Regex = /(?:(-?\d*\.?\d*)\s*(?:years?|yrs?|y)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:weeks?|w)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:days?|d)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:hours?|hrs?|h)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:minutes?|mins?|m(?!s|i))(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:seconds?|secs?|s)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:milliseconds?|msecs?|ms|$))?/gim;
+  const l_Regex = /(?:(-?\d*\.?\d*)\s*(?:years?|yrs?|y)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:months?|mos?|mths?)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:weeks?|w)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:days?|d)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:hours?|hrs?|h)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:minutes?|mins?|m(?!s|i))(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:seconds?|secs?|s)(?![A-Za-z]))?\s*(?:(-?\d*\.?\d*)\s*(?:milliseconds?|msecs?|ms|$))?/gim;
 
   const l_Match = l_Regex.exec(str);
 
@@ -62,22 +63,25 @@ function parse(str) {
       l_Match[5],
       l_Match[6],
       l_Match[7],
+      l_Match[8],
     ].some((group) => group !== undefined)
   ) {
     return NaN;
   }
 
   const yearsValue = l_Match[1];
-  const weeksValue = l_Match[2];
-  const daysValue = l_Match[3];
-  const hoursValue = l_Match[4];
-  const minsValue = l_Match[5];
-  const secsValue = l_Match[6];
-  const msecsValue = l_Match[7];
+  const monthsValue = l_Match[2];
+  const weeksValue = l_Match[3];
+  const daysValue = l_Match[4];
+  const hoursValue = l_Match[5];
+  const minsValue = l_Match[6];
+  const secsValue = l_Match[7];
+  const msecsValue = l_Match[8];
 
   let l_TotalMS = 0;
 
   if (yearsValue != undefined) l_TotalMS += parseFloat(yearsValue) * y;
+  if (monthsValue != undefined) l_TotalMS += parseFloat(monthsValue) * M;
   if (weeksValue != undefined) l_TotalMS += parseFloat(weeksValue) * w;
   if (daysValue != undefined) l_TotalMS += parseFloat(daysValue) * d;
   if (hoursValue != undefined) l_TotalMS += parseFloat(hoursValue) * h;

--- a/tests.js
+++ b/tests.js
@@ -316,4 +316,10 @@ describe('BetterMsJS - Breaking Changes compared to vercel/ms 2.1.3', function (
   it('should not support a input with random characters after a valid time unit', function () {
     expect(isNaN(ms('1daysbc'))).to.be(true);
   });
+
+  it('should support months', function () {
+    expect(ms('1mo')).to.be(2629800000);
+    expect(ms('1mth')).to.be(2629800000);
+    expect(ms('1month')).to.be(2629800000);
+  });
 });


### PR DESCRIPTION
This pull request adds support for parsing time durations in months in the parse function of the code. Previously, the code only supported parsing time durations in years, weeks, days, hours, minutes, seconds, and milliseconds. With this change, users can now input time durations in months and have them correctly parsed.